### PR TITLE
Fix Vivado syntax error

### DIFF
--- a/hw/ram.v
+++ b/hw/ram.v
@@ -1,5 +1,5 @@
 module ram #(
-    parameter ADDR_BITS = 10,
+    parameter ADDR_BITS = 10
 ) (
     input clk,
     input valid,


### PR DESCRIPTION
This line was a syntax error in Xilinx Vivado 2018.3. Vivado doesn't seem to like trailing commas in parameter lists, even though it's fine using the Yosys toolchain.